### PR TITLE
Fix sesskey validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# npm
+/node_modules/
+/npm-*.log
+/package-lock.json
+
+# Build artifacts
+/amd/build/

--- a/classes/form/no_sesskey_form.php
+++ b/classes/form/no_sesskey_form.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Enhanced authentication.
+ *
+ * @author Luke Carrier <luke.carrier@floream.com>
+ * @copyright 2016 Floream Limited
+ */
+
+namespace local_signin\form;
+
+use moodleform;
+use stdClass;
+
+defined('MOODLE_INTERNAL') || die;
+/** @var stdClass $CFG */
+
+require_once "{$CFG->libdir}/formslib.php";
+
+/**
+ * Sesskey-less form.
+ *
+ * An ordinary Moodle form with sesskey validation disabled during submission
+ * processing. Use of this class poses a potential security hazard (cross site
+ * request forgery) when used for potentially destructive operations -- think
+ * through your use case carefully.
+ */
+abstract class no_sesskey_form extends moodleform {
+    /**
+     * @inheritdoc moodleform
+     */
+    function _process_submission($method) {
+        global $USER;
+
+        $oldignoresesskey = property_exists($USER, 'ignoresesskey')
+                && $USER->ignoresesskey;
+        try {
+            $USER->ignoresesskey = true;
+            parent::_process_submission($method);
+        } finally {
+            $USER->ignoresesskey = $oldignoresesskey;
+        }
+    }
+}

--- a/classes/form/password_form.php
+++ b/classes/form/password_form.php
@@ -16,9 +16,7 @@ use moodleform;
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once "{$CFG->libdir}/formslib.php";
-
-class password_form extends moodleform {
+class password_form extends no_sesskey_form {
     /**
      * @override \moodleform
      */

--- a/classes/form/username_form.php
+++ b/classes/form/username_form.php
@@ -20,9 +20,7 @@ use moodleform;
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once "{$CFG->libdir}/formslib.php";
-
-class username_form extends moodleform {
+class username_form extends no_sesskey_form {
     /**
      * @override \moodleform
      */

--- a/index.php
+++ b/index.php
@@ -18,6 +18,7 @@ use local_signin\form\password_form;
 use local_signin\form\username_form;
 
 require_once dirname(dirname(__DIR__)) . '/config.php';
+/** @var moodle_page $PAGE */
 
 redirect_if_major_upgrade_required();
 


### PR DESCRIPTION
Exclude the username and password forms from sesskey validation, as users can authenticate prior to a user session [being created](https://www.youtube.com/watch?v=YeFk00wlXJs), which causes `sesskey` to change on every request.