### PR TITLE
Username and email address fields should not be case sensitive

### DIFF
--- a/classes/domainfinder/user_default_domain.php
+++ b/classes/domainfinder/user_default_domain.php
@@ -82,10 +82,10 @@ class user_default_domain {
         $domainfinder = (is_object($class)) ? $class : new $class();
         /** @var default_domain_finder $domainfinder */
 
-        $where =  'username = :username';
+        $where =  'LOWER(username) = LOWER(:username)';
         $params = array('username' => $input);
         if ($CFG->authloginviaemail) {
-            $where .= " OR email = :email";
+            $where .= " OR LOWER(email) = LOWER(:email)";
             $params['email'] = $input;
         }
 

--- a/tests/behat/login_javascript.feature
+++ b/tests/behat/login_javascript.feature
@@ -119,3 +119,17 @@ Feature: Log in to platform
     And I set the field "password" to "pass1"
     And I press "Log In"
     Then the URL path should be "/user/profile.php"
+
+  @javascript
+  Scenario: 11. Username search is case insensitive.
+    When I set the field "username" to "STUDENT1"
+    And I press "Proceed"
+    Then "password" "field" should be visible
+
+  @javascript
+  Scenario: 12. Email search is case insensitive.
+    Given the following "core" configuration values are set:
+      | authloginviaemail | 1 |
+    When I set the field "username" to "STUDENT1@EXAMPLE.COM"
+    And I press "Proceed"
+    Then "password" "field" should be visible

--- a/tests/unit/default_domain_test.php
+++ b/tests/unit/default_domain_test.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot . '/auth/manual/auth.php');
 require_once($CFG->dirroot . '/local/signin/classes/helper/login_helper.php'); // Include the code to test.
 
 /**
- * Test case for local_signin.
+ * Default domain test cases.
  *
  * @group local_signin
  */
@@ -43,6 +43,8 @@ class local_signin_default_domain_testcase extends advanced_testcase {
     protected $user;
 
     public function setUp() {
+        $this->resetAfterTest();
+
         $generator = $this->getDataGenerator();
         $this->user = $generator->create_user();
     }
@@ -58,7 +60,6 @@ class local_signin_default_domain_testcase extends advanced_testcase {
     //        ->with(array($this->user->username))
     //        ->willReturn('example.com');
     //
-    //    $this->resetAfterTest();
     //    $CFG->local_signin_domainfinder = $domainfinder;
     //
     //    user_default_domain::get($this->user->username);

--- a/tests/unit/default_domain_test.php
+++ b/tests/unit/default_domain_test.php
@@ -64,4 +64,49 @@ class local_signin_default_domain_testcase extends advanced_testcase {
     //
     //    user_default_domain::get($this->user->username);
     //}
+
+    public function test_get_by_username() {
+        $result = user_default_domain::get($this->user->username);
+        $this->assertEquals($this->user->username, $result->username);
+        $this->assertEquals($this->user->email, $result->email);
+    }
+
+    public function test_get_by_invalid_username() {
+        $result = user_default_domain::get("{$this->user->username}-INVALID");
+        $this->assertEquals(null, $result->username);
+        $this->assertEquals(null, $result->email);
+    }
+
+    public function test_get_honours_authloginviaemail_false() {
+        global $CFG;
+
+        $CFG->authloginviaemail = false;
+        $result = user_default_domain::get($this->user->email);
+        $this->assertEquals(null, $result->username);
+        $this->assertEquals(null, $result->email);
+    }
+
+    public function test_get_honours_authloginviaemail_true() {
+        global $CFG;
+
+        $CFG->authloginviaemail = true;
+        $result = user_default_domain::get($this->user->email);
+        $this->assertEquals($this->user->username, $result->username);
+        $this->assertEquals($this->user->email, $result->email);
+    }
+
+    public function test_get_username_is_case_insensitive() {
+        $result = user_default_domain::get(strtoupper($this->user->username));
+        $this->assertEquals($this->user->username, $result->username);
+        $this->assertEquals($this->user->email, $result->email);
+    }
+
+    public function test_get_email_is_case_insensitive() {
+        global $CFG;
+
+        $CFG->authloginviaemail = true;
+        $result = user_default_domain::get(strtoupper($this->user->email));
+        $this->assertEquals($this->user->username, $result->username);
+        $this->assertEquals($this->user->email, $result->email);
+    }
 }


### PR DESCRIPTION
* Add test coverage for `user_default_domain`, both around `authloginviaemail` and case sensitivity of both the username and email search.
* Use `LOWER()` around both input and data when looking up users.