### PR TITLE
Alp 274 - Changing exception type to catch null domain values

### DIFF
--- a/classes/domainfinder/user_default_domain.php
+++ b/classes/domainfinder/user_default_domain.php
@@ -10,6 +10,7 @@
 namespace local_signin\domainfinder;
 
 use dml_missing_record_exception;
+use Exception;
 use local_signin\interfaces\static_default_domain;
 use local_signin\interfaces\default_domain_finder;
 use local_signin\util;
@@ -104,7 +105,7 @@ class user_default_domain {
             try {
                 // If the user has a brand default domain (via a cohort), update $result accordingly.
                 $result->domain = $domainfinder->get_user_domain();
-            } catch (dml_missing_record_exception $e) {
+            } catch (Exception $e) {
                 // No default, so give the "default" login domain.
                 $result->domain = $CFG->local_signin_defaultdomain;
             }

--- a/tests/unit/default_domain_test.php
+++ b/tests/unit/default_domain_test.php
@@ -118,5 +118,4 @@ class local_signin_default_domain_testcase extends advanced_testcase {
         $result = user_default_domain::get($this->user->username);
         $this->assertEquals($CFG->local_signin_defaultdomain, $result->domain);
     }
-
 }

--- a/tests/unit/default_domain_test.php
+++ b/tests/unit/default_domain_test.php
@@ -109,4 +109,14 @@ class local_signin_default_domain_testcase extends advanced_testcase {
         $this->assertEquals($this->user->username, $result->username);
         $this->assertEquals($this->user->email, $result->email);
     }
+
+    public function test_get_user_fallback_to_default_domain() {
+        global $CFG;
+        $CFG->local_signin_domainfinder  = '\\bmext_signindomain\\default_domain_finder';
+        $CFG->local_signin_defaultdomain = 'default.domain';
+
+        $result = user_default_domain::get($this->user->username);
+        $this->assertEquals($CFG->local_signin_defaultdomain, $result->domain);
+    }
+
 }


### PR DESCRIPTION
Links to ticket [ALP-274](https://avadolearning.atlassian.net/browse/ALP-274)

[Partner PR](https://bitbucket.org/avadolearning/bmext_signindomain/pull-requests/3/fixed-changed-domain-finder-to-return/diff) (bmext_signindomain)

Reviewer: @LukeCarrier 