### PR TITLE
Alp 617

### DIFF
--- a/amd/src/login.js
+++ b/amd/src/login.js
@@ -172,6 +172,7 @@ define(['jquery', 'core/ajax', 'core/str'], function($, ajax, str) {
             // Toggle the forms
             options.username.container.addClass('hide');
             options.password.container.removeClass('hide');
+            document.getElementById("id_password").focus();
         }
     }
 

--- a/forgot.php
+++ b/forgot.php
@@ -24,7 +24,7 @@ $token = optional_param('token', '', PARAM_ALPHANUM);
 $forgotten = get_string('form_page_title', util::MOODLE_COMPONENT);
 $login     = get_string('login');
 
-if (version_compare(moodle_major_version(), '3.4.0', '<')) {
+if (version_compare(moodle_major_version(), '3.4', '<')) {
     $PAGE->https_required();
 }
 $PAGE->set_cacheable(false);
@@ -87,7 +87,7 @@ if ($token) {
                         get_string('passwordset'));
         }
     } else {
-        if (version_compare(moodle_major_version(), '3.4.0', '<')) {
+        if (version_compare(moodle_major_version(), '3.4', '<')) {
             $PAGE->verify_https_required();
         }
 
@@ -135,7 +135,7 @@ if ($token) {
             }
         }
     } else {
-        if (version_compare(moodle_major_version(), '3.4.0', '<')) {
+        if (version_compare(moodle_major_version(), '3.4', '<')) {
             $PAGE->verify_https_required();
         }
 

--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ if ($helper->is_user_already_loggedin()) {
     $helper->redirect_to_logout_page();
 }
 
-if (version_compare(moodle_major_version(), '3.4.0', '<')) {
+if (version_compare(moodle_major_version(), '3.4', '<')) {
     $PAGE->https_required();
 }
 


### PR DESCRIPTION
The Avado platform was throwing a https_required() deprecation message which was due to our logical error in the version_compare condition. we were comparing 3.4 with 3.4.0 which returned true all the time, so the https_required() was called on Avado platform when it shouldn't. now that this is fixed, all tests pass. 