### PR TITLE
Removing user details like email/username in Json Response in local_signin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 
 # Build artifacts
 /amd/build/
+
+/vendor/
+/composer.lock
+
+.idea/

--- a/amd/src/login.js
+++ b/amd/src/login.js
@@ -162,7 +162,7 @@ define(['jquery', 'core/ajax', 'core/str'], function($, ajax, str) {
      */
     function maybeDomainRedirect(response, username, options) {
         var currentURL = window.location;
-        if (response.email === null) {
+        if (response.userdetail === null) {
             getStringAndNotify('danger', 'form_username_not_found_valid');
         } else if (response.domain !== currentURL.hostname) {
             redirect(response, username);

--- a/classes/external.php
+++ b/classes/external.php
@@ -48,8 +48,7 @@ class external extends external_api {
     public static function check_domain_returns() {
         return new external_single_structure(array(
             'domain'   => new external_value(PARAM_URL, 'Domain for user associated brand'),
-            'username' => new external_value(PARAM_USERNAME, 'Username'),
-            'email'    => new external_value(PARAM_TEXT, 'User email'),
+            'userdetail' => new external_value(PARAM_USERNAME, 'Username or email entered by user')
         ));
     }
 }


### PR DESCRIPTION
Before when user logins to Local_signin, it doesn't matter with what details user logins to the portal but the email of the logging user is visible in the json response in the console. Now, if user logins with username then the username will only be visible in the console and if user login with email then only email can be visible in the console as Json Response.

@MrJons @hannahlillis @udayavado @ajaySurti @vijay @celine
![Screenshot from 2019-05-03 15-59-36](https://user-images.githubusercontent.com/50168627/57132206-7c684c00-6dbc-11e9-8b72-cdd09c0c42cf.png)
